### PR TITLE
Search for libperfmap.so in java.library.path if not found in CWD

### DIFF
--- a/src/java/AttachOnce.java
+++ b/src/java/AttachOnce.java
@@ -39,10 +39,21 @@ public class AttachOnce {
             File lib = new File("libperfmap.so");
             String fullPath = lib.getAbsolutePath();
             if (!lib.exists()) {
-                System.out.printf("Expected libperfmap.so at '%s' but it didn't exist.\n", fullPath);
-                System.exit(1);
+                String [] javaLibPath = System.getProperty("java.library.path").split(":");
+                boolean foundInLibPath = false;
+                for (String path: javaLibPath) {
+                    File f = new File(path + File.separator + "libperfmap.so");
+                    if(f.exists()) {
+                        foundInLibPath = true;
+                        fullPath = f.getAbsolutePath();
+                    }
+                }
+                if (!foundInLibPath) {
+                    System.out.printf("Expected libperfmap.so at '%s' or within java.library.path but it didn't exist in either.\n", fullPath);
+                    System.exit(1);
+                }
             }
-            else vm.loadAgentPath(fullPath, options);
+            vm.loadAgentPath(fullPath, options);
         } catch(com.sun.tools.attach.AgentInitializationException e) {
             // rethrow all but the expected exception
             if (!e.getMessage().equals("Agent_OnAttach failed")) throw e;


### PR DESCRIPTION
Hi @jrudolph,

It can be inconvenient to have to always having to change a directory where libperfmap.so is located in order to dump Java symbols.

Search for libperfmap.so in java.library.path if not found in CWD, use one that exists within  java.library.path. This allows for usage like:

```
AGENT_HOME=/opt/perf-map-agent
java -Djava.library.path=$AGENT_HOME -cp $JAVA_HOME/lib/tools.jar:$AGENT_HOME/attach-main.jar net.virtualvoid.perf.AttachOnce $PID
```